### PR TITLE
Force IntelliJ to treat all postfix template files as UTF-8

### DIFF
--- a/src/de/endrullis/idea/postfixtemplates/language/CptFileType.java
+++ b/src/de/endrullis/idea/postfixtemplates/language/CptFileType.java
@@ -1,6 +1,7 @@
 package de.endrullis.idea.postfixtemplates.language;
 
 import com.intellij.openapi.fileTypes.LanguageFileType;
+import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,5 +36,10 @@ public class CptFileType extends LanguageFileType {
 	@Override
 	public Icon getIcon() {
 		return CptIcons.FILE;
+	}
+
+	@Override
+	public String getCharset(@NotNull VirtualFile file, @NotNull byte[] content) {
+		return "UTF-8";
 	}
 }


### PR DESCRIPTION
Without this, IntelliJ will use the global encoding to load the custom files when opening them into the editor causing encoding issues.