### PR TITLE
Add Date/Calendar templates for java language

### DIFF
--- a/templates/webTemplateFiles.yaml
+++ b/templates/webTemplateFiles.yaml
@@ -4,7 +4,7 @@
   author: Cassius Cai
   email: cassiuscai@gmail.com
   website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/commons-lang.date.md
-  description: Provides templates for operate on the Date/Calendar API
+  description: Provides templates for the Date/Calendar API
 - lang: java
   id: cassiuscai.assertj-core
   url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/assertj-core.postfixTemplates

--- a/templates/webTemplateFiles.yaml
+++ b/templates/webTemplateFiles.yaml
@@ -1,26 +1,33 @@
 - lang: java
-  id: casc.common-assert
-  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/common-assert.postfixTemplates
+  id: cassiuscai.misc-require
+  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/misc-require.postfixTemplates
   author: Cassius Cai
   email: cassiuscai@gmail.com
-  website: https://github.com/cassiuscai/postfix-templates/blob/master/README.md
-  description: Provides templates for argument check
+  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/misc-require.md
+  description: Provides templates for check Array/Collection/Map/String/Boolean Arguments
 - lang: java
-  id: casc.assertj-core
+  id: cassiuscai.misc-empty
+  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/misc-empty.postfixTemplates
+  author: Cassius Cai
+  email: cassiuscai@gmail.com
+  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/misc-empty.md
+  description: Provides templates to check the Array/Collection/Map/String is or not empty
+- lang: java
+  id: cassiuscai.assertj-core
   url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/assertj-core.postfixTemplates
   author: Cassius Cai
   email: cassiuscai@gmail.com
   website: https://github.com/cassiuscai/postfix-templates/blob/master/README.md
   description: Provides templates for assertj core assertThat API
 - lang: java
-  id: casc.mockito
+  id: cassiuscai.mockito
   url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/mockito.postfixTemplates
   author: Cassius Cai
   email: cassiuscai@gmail.com
   website: https://github.com/cassiuscai/postfix-templates/blob/master/README.md
   description: Provides templates for Mockito API
 - lang: java
-  id: casc.guava-string
+  id: cassiuscai.guava-string
   url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/guava-string.postfixTemplates
   author: Cassius Cai
   email: cassiuscai@gmail.com

--- a/templates/webTemplateFiles.yaml
+++ b/templates/webTemplateFiles.yaml
@@ -1,9 +1,23 @@
 - lang: java
-  id: cassiuscai.misc-require
-  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/misc-require.postfixTemplates
+  id: cassiuscai.date-operation
+  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/date-operation.postfixTemplates
   author: Cassius Cai
   email: cassiuscai@gmail.com
-  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/misc-require.md
+  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/date-operation.md
+  description: Provides templates for operations for the Date/Calendar API
+- lang: java
+  id: cassiuscai.date-format
+  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/date-format.postfixTemplates
+  author: Cassius Cai
+  email: cassiuscai@gmail.com
+  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/date-format.md
+  description: Provides templates for format and parse Date
+- lang: java
+  id: cassiuscai.misc-argument
+  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/misc-argument.postfixTemplates
+  author: Cassius Cai
+  email: cassiuscai@gmail.com
+  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/misc-argument.md
   description: Provides templates for check Array/Collection/Map/String/Boolean Arguments
 - lang: java
   id: cassiuscai.misc-empty

--- a/templates/webTemplateFiles.yaml
+++ b/templates/webTemplateFiles.yaml
@@ -1,31 +1,10 @@
 - lang: java
-  id: cassiuscai.date-operation
-  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/date-operation.postfixTemplates
+  id: cassiuscai.commons-lang.date
+  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/commons-lang.date.postfixTemplates
   author: Cassius Cai
   email: cassiuscai@gmail.com
-  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/date-operation.md
+  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/commons-lang.date.md
   description: Provides templates for operate on the Date/Calendar API
-- lang: java
-  id: cassiuscai.date-format
-  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/date-format.postfixTemplates
-  author: Cassius Cai
-  email: cassiuscai@gmail.com
-  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/date-format.md
-  description: Provides templates for format and parse Date
-- lang: java
-  id: cassiuscai.misc-argument
-  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/misc-argument.postfixTemplates
-  author: Cassius Cai
-  email: cassiuscai@gmail.com
-  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/misc-argument.md
-  description: Provides templates for check Array/Collection/Map/String/Boolean Arguments
-- lang: java
-  id: cassiuscai.misc-empty
-  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/misc-empty.postfixTemplates
-  author: Cassius Cai
-  email: cassiuscai@gmail.com
-  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/misc-empty.md
-  description: Provides templates to check the Array/Collection/Map/String is or not empty
 - lang: java
   id: cassiuscai.assertj-core
   url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/assertj-core.postfixTemplates

--- a/templates/webTemplateFiles.yaml
+++ b/templates/webTemplateFiles.yaml
@@ -1,19 +1,26 @@
 - lang: java
-  id: cassiuscai.assertj-core
+  id: casc.common-assert
+  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/common-assert.postfixTemplates
+  author: Cassius Cai
+  email: cassiuscai@gmail.com
+  website: https://github.com/cassiuscai/postfix-templates/blob/master/README.md
+  description: Provides templates for argument check
+- lang: java
+  id: casc.assertj-core
   url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/assertj-core.postfixTemplates
   author: Cassius Cai
   email: cassiuscai@gmail.com
   website: https://github.com/cassiuscai/postfix-templates/blob/master/README.md
   description: Provides templates for assertj core assertThat API
 - lang: java
-  id: cassiuscai.mockito
+  id: casc.mockito
   url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/mockito.postfixTemplates
   author: Cassius Cai
   email: cassiuscai@gmail.com
   website: https://github.com/cassiuscai/postfix-templates/blob/master/README.md
   description: Provides templates for Mockito API
 - lang: java
-  id: cassiuscai.guava-string
+  id: casc.guava-string
   url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/guava-string.postfixTemplates
   author: Cassius Cai
   email: cassiuscai@gmail.com

--- a/templates/webTemplateFiles.yaml
+++ b/templates/webTemplateFiles.yaml
@@ -4,7 +4,7 @@
   author: Cassius Cai
   email: cassiuscai@gmail.com
   website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/date-operation.md
-  description: Provides templates for operations for the Date/Calendar API
+  description: Provides templates for operate on the Date/Calendar API
 - lang: java
   id: cassiuscai.date-format
   url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/date-format.postfixTemplates


### PR DESCRIPTION
- [Templates for the `Date/Calendar` API](https://github.com/cassiuscai/postfix-templates/blob/master/documents/date-operation.md)