### PR TITLE
Add additional postfixes for python

### DIFF
--- a/templates/python/stdlib.postfixTemplates
+++ b/templates/python/stdlib.postfixTemplates
@@ -3,3 +3,54 @@
 
 .reversed : Reverse iterable
 	ANY   →   reversed($expr$)
+
+.sort : Sort iterable
+	ANY   →   sort($expr$)$END$
+
+.sortk : Sort iterable with key
+	ANY   →   sort($expr$, key=$key$)$END$
+
+.sortl : Sort iterable with lambda key
+	ANY   →   sort($expr$, key=lambda o: $key$)$END$
+
+.filter : Filter iterable
+	ANY   →   filter($first$, $expr$)$END$
+
+.filterl : Filter iterable with lambda
+	ANY   →   filter(lambda o: $first$, $expr$)$END$
+
+.map : Map iterable
+	ANY   →   map($first$, $expr$)$END$
+
+.mapl : Map iterable with lambda
+	ANY   →   map(lambda o: $first$, $expr$)$END$
+
+.open : Open a path
+	ANY   →   with open($expr$) as $file_name$:\
+    $END$
+
+.openm : Open a path with mode
+	ANY   →   with open($expr$, mode='$mode$') as $file_name$:\
+    $END$
+
+.openp : Open a Path object
+	ANY   →   with closing($expr$.open()) as $file_name$:\
+    $END$
+
+.for : Iterate through an object
+	ANY   →   for $var$ as $expr$:\
+    $END$
+
+.try : Wrap with try except
+	ANY   →   try:\
+    $expr$\
+except $error$ as $error_var$:\
+    $END$
+
+.tryf : Wrap with try except and finally
+	ANY   →   try:\
+    $expr$\
+except $error$ as $error_var$:\
+    $except$\
+finally:\
+    $END$


### PR DESCRIPTION
There is not much to say about this, I do have a question though. Is it ok to add this to the current python template file? I am not sure because the files are named by the author via the `yaml` https://github.com/xylo/intellij-postfix-templates/blob/8b616fc1730679a7c9820fe6cd858b7a208093e8/templates/webTemplateFiles.yaml#L230-L231