### PR TITLE
Add postfix to convert java object to Vavr Objects & AssertJ Support

### DIFF
--- a/templates/webTemplateFiles.yaml
+++ b/templates/webTemplateFiles.yaml
@@ -13,6 +13,13 @@
   website: https://github.com/cassiuscai/postfix-templates/blob/master/README.md
   description: Provides templates for assertj vavr assertThat API
 - lang: java
+  id: cassiuscai.commons-lang.date
+  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/commons-lang.date.postfixTemplates
+  author: Cassius Cai
+  email: cassiuscai@gmail.com
+  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/commons-lang.date.md
+  description: Provides templates for the Date/Calendar API
+- lang: java
   id: cassiuscai.assertj-core
   url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/assertj-core.postfixTemplates
   author: Cassius Cai

--- a/templates/webTemplateFiles.yaml
+++ b/templates/webTemplateFiles.yaml
@@ -1,10 +1,17 @@
 - lang: java
-  id: cassiuscai.commons-lang.date
-  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/commons-lang.date.postfixTemplates
+  id: cassiuscai.vavr
+  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/vavr.postfixTemplates
   author: Cassius Cai
   email: cassiuscai@gmail.com
-  website: https://github.com/cassiuscai/postfix-templates/blob/master/documents/commons-lang.date.md
-  description: Provides templates for the Date/Calendar API
+  website: https://github.com/cassiuscai/postfix-templates/blob/master/README.md
+  description: Provides templates for the VAVR(javaslang) Library
+- lang: java
+  id: cassiuscai.assertj-vavr
+  url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/assertj-vavr.postfixTemplates
+  author: Cassius Cai
+  email: cassiuscai@gmail.com
+  website: https://github.com/cassiuscai/postfix-templates/blob/master/README.md
+  description: Provides templates for assertj vavr assertThat API
 - lang: java
   id: cassiuscai.assertj-core
   url: https://raw.githubusercontent.com/cassiuscai/postfix-templates/master/templates/assertj-core.postfixTemplates


### PR DESCRIPTION
### Vavr
- Seq
	- `.toVavrArray`
	- `.toVavrQueue`
	- `.toVavrVector`
	- `.toVavrStream`
	- `.toVavrList`
- Set
	- `.toVavrHashSet`
	- `.toVavrLinkedHashSet`
	- `.toVavrTreeSet`
- Map
	- `.toVavrHashMap`
	- `.toVavrLinkedHashMap`
	- `.toVavrTreeMap`
- FP
	- `.toVavrTry`
	- `.toVavrLazy`
	- `.toVavrOption`
- Match
	- `.vavrMatchOrElseValue`
	- `.vavrMatchOrElseThrow`

### AssertJ Vavr
- VavrAssertions
        - `.assertVavr`