### PR TITLE
Fix the wrong syntax

### DIFF
--- a/templates/python/stdlib.postfixTemplates
+++ b/templates/python/stdlib.postfixTemplates
@@ -38,7 +38,7 @@
     $END$
 
 .for : Iterate through an object
-	ANY   →   for $var$ as $expr$:\
+	ANY   →   for $var$ in $expr$:\
     $END$
 
 .try : Wrap with try except


### PR DESCRIPTION
Syntax error:
for-loop use `in` rather than `as`
Ref: [https://docs.python.org/3/reference/compound_stmts.html#the-for-statement](https://docs.python.org/3/reference/compound_stmts.html#the-for-statement)