### PR TITLE
resolves #177

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,24 +49,24 @@ sourceSets {
 intellij {
     // full list of IntelliJ IDEA releases at https://www.jetbrains.com/intellij-repository/releases
     // full list of IntelliJ IDEA EAP releases at https://www.jetbrains.com/intellij-repository/snapshots
-    version 'IU-2020.1'
+    version 'IU-203.4818.26-EAP-SNAPSHOT'
     //version '2018.2.2'
     sandboxDirectory project.rootDir.canonicalPath + "/.sandbox"
     plugins 'java',
             //'PythonCore:201.6073.9',
-            'Pythonid:201.6668.121',
+            'Pythonid:203.4818.26',
             'Kotlin',
-            'org.intellij.scala:2020.1.27',
+            'org.intellij.scala:2020.3.8',
             'JavaScriptLanguage',
             'CSS',
-            'Dart:201.6668.156',
+            'Dart:203.4818.26',
             'Groovy',
             'properties',
-            'org.jetbrains.plugins.ruby:201.6668.113',
-            'com.jetbrains.php:201.6668.153',
+            'org.jetbrains.plugins.ruby:203.4818.26',
+            'com.jetbrains.php:203.4818.52',
             'java-i18n',
             'DatabaseTools',
-            'org.jetbrains.plugins.go:201.6668.60.126'
+            'org.jetbrains.plugins.go:203.4818.26'
     updateSinceUntilBuild true
 
 //    plugins = ["PythonCore:2018.2.182.3684.101"]

--- a/src/de/endrullis/idea/postfixtemplates/languages/scala/CustomScalaStringPostfixTemplate.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/scala/CustomScalaStringPostfixTemplate.java
@@ -5,14 +5,12 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.Condition;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.containers.OrderedSet;
-import de.endrullis.idea.postfixtemplates.settings.CustomPostfixTemplates;
 import de.endrullis.idea.postfixtemplates.templates.MyVariable;
 import de.endrullis.idea.postfixtemplates.templates.NavigatablePostfixTemplate;
 import de.endrullis.idea.postfixtemplates.templates.SpecialType;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.plugins.scala.annotator.intention.ScalaAddImportAction;
 import org.jetbrains.plugins.scala.lang.completion.postfix.templates.ScalaStringBasedPostfixTemplate;
 import org.jetbrains.plugins.scala.lang.completion.postfix.templates.selector.AncestorSelector;
 import org.jetbrains.plugins.scala.lang.psi.ScImportsHolder;
@@ -38,7 +36,7 @@ public class CustomScalaStringPostfixTemplate extends ScalaStringBasedPostfixTem
 
 	static final Pattern IMPORT_PATTERN = Pattern.compile("\\[IMPORT ([^\\]]+)\\]");
 
-	private static final Map<String, Condition<PsiElement>> type2psiCondition = new HashMap<String, Condition<PsiElement>>() {{
+	private static final Map<String, Condition<PsiElement>> type2psiCondition = new HashMap<>() {{
 		put(SpecialType.ANY.name(), e -> true);
 		put(SpecialType.VOID.name(), VOID);
 		put(SpecialType.NON_VOID.name(), NON_VOID);
@@ -157,7 +155,7 @@ public class CustomScalaStringPostfixTemplate extends ScalaStringBasedPostfixTem
 	}
 
 	private void addImport(@NotNull PsiElement expr, String qualifiedName) {
-		ScImportsHolder importHolder = ScalaAddImportAction.getImportHolder(expr, expr.getProject());
+		ScImportsHolder importHolder = ScImportsHolder.apply(expr, expr.getProject());
 
 		boolean imported = importHolder.getAllImportUsed().exists(i -> i.qualName().exists(n -> n.equals(qualifiedName)));
 

--- a/src/de/endrullis/idea/postfixtemplates/languages/scala/ScalaPostfixTemplatesUtils.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/scala/ScalaPostfixTemplatesUtils.java
@@ -3,7 +3,7 @@ package de.endrullis.idea.postfixtemplates.languages.scala;
 import com.intellij.openapi.util.Condition;
 import com.intellij.psi.PsiElement;
 import org.jetbrains.plugins.scala.lang.completion.postfix.templates.selector.AncestorSelector;
-import scala.collection.JavaConverters;
+import scala.jdk.javaapi.CollectionConverters;
 
 import java.util.Arrays;
 import java.util.List;
@@ -32,7 +32,7 @@ class ScalaPostfixTemplatesUtils {
 	}
 
 	public static Condition<PsiElement> isDescendant(List<String> classes) {
-		return AncestorSelector.isSameOrInheritor(JavaConverters.asScalaBuffer(classes));
+		return AncestorSelector.isSameOrInheritor(CollectionConverters.asScala(classes).toSeq());
 	}
 
 }


### PR DESCRIPTION
Updated dependency versions to EAP 203
Fixed CustomScalaStringPostfixTemplate due to refactoring in the scala plugin
Fixed ScalaPostfixTemplatesUtils.isDescendant by changing Buffer to Seq because now Buffer is not working.
Changed deprecated scala.collection.JavaConverters to new CollectionConverters

Due to EAP, I believe this shouldn't be merged to master, but to separate branch.