### PR TITLE
[Feature] Introduce support for Ruby

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -510,10 +510,14 @@
 	<depends optional="true" config-file="withGroovyModule.xml">org.intellij.groovy</depends>
 	<!--<depends optional="true" config-file="withGoModule.xml">com.intellij.modules.go-capable</depends>-->
 	<depends optional="true" config-file="withGoModule.xml">org.jetbrains.plugins.go</depends>
+	<!-- Requires the Ruby plugin -->
+	<depends optional="true" config-file="withRubyModule.xml">com.intellij.modules.ruby</depends>
 
 	<extensions defaultExtensionNs="com.intellij">
 		<notificationGroup id="Custom Postfix Templates" displayType="STICKY_BALLOON"/>
 
+		<codeInsight.template.postfixTemplateProvider language="ruby"
+		                                              implementationClass="de.endrullis.idea.postfixtemplates.languages.ruby.RubyPostfixTemplateProvider"/>
 		<codeInsight.template.postfixTemplateProvider language="JavaScript"
 		                                              implementationClass="de.endrullis.idea.postfixtemplates.languages.javascript.JavaScriptPostfixTemplateProvider"/>
 		<codeInsight.template.postfixTemplateProvider language="SQL"

--- a/resources/META-INF/withRubyModule.xml
+++ b/resources/META-INF/withRubyModule.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+	<extensions defaultExtensionNs="com.intellij">
+		<codeInsight.template.postfixTemplateProvider language="Ruby"
+		                                              implementationClass="de.endrullis.idea.postfixtemplates.languages.ruby.RubyPostfixTemplateProvider"/>
+	</extensions>
+</idea-plugin>

--- a/resources/postfixTemplates/CustomRubyStringPostfixTemplate/after.java.template
+++ b/resources/postfixTemplates/CustomRubyStringPostfixTemplate/after.java.template
@@ -1,0 +1,2 @@
+// this is a custom template defined by the user
+// see "Custom Postfix Templates" for template definition

--- a/resources/postfixTemplates/CustomRubyStringPostfixTemplate/before.java.template
+++ b/resources/postfixTemplates/CustomRubyStringPostfixTemplate/before.java.template
@@ -1,0 +1,2 @@
+// this is a custom template defined by the user
+// see "Custom Postfix Templates" for template definition

--- a/resources/postfixTemplates/CustomRubyStringPostfixTemplate/description.html
+++ b/resources/postfixTemplates/CustomRubyStringPostfixTemplate/description.html
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2000-2017 JetBrains s.r.o.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<html>
+<body>
+
+Custom postfix template.
+</body>
+</html>

--- a/src/de/endrullis/idea/postfixtemplates/languages/SupportedLanguages.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/SupportedLanguages.java
@@ -13,6 +13,7 @@ import de.endrullis.idea.postfixtemplates.languages.javascript.JavaScriptLang;
 import de.endrullis.idea.postfixtemplates.languages.kotlin.KotlinLang;
 import de.endrullis.idea.postfixtemplates.languages.php.PhpLang;
 import de.endrullis.idea.postfixtemplates.languages.python.PythonLang;
+import de.endrullis.idea.postfixtemplates.languages.ruby.RubyLang;
 import de.endrullis.idea.postfixtemplates.languages.rust.RustLang;
 import de.endrullis.idea.postfixtemplates.languages.scala.ScalaLang;
 import de.endrullis.idea.postfixtemplates.languages.sql.SqlLang;
@@ -43,6 +44,7 @@ public class SupportedLanguages {
 			new KotlinLang(),
 			new PhpLang(),
 			new PythonLang(),
+			new RubyLang(),
 			new RustLang(),
 			new ScalaLang(),
 			new SqlLang()

--- a/src/de/endrullis/idea/postfixtemplates/languages/ruby/CustomRubyStringPostfixTemplate.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/ruby/CustomRubyStringPostfixTemplate.java
@@ -1,0 +1,33 @@
+package de.endrullis.idea.postfixtemplates.languages.ruby;
+
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateProvider;
+import com.intellij.openapi.util.Condition;
+import com.intellij.psi.PsiElement;
+import de.endrullis.idea.postfixtemplates.templates.SimpleStringBasedPostfixTemplate;
+import de.endrullis.idea.postfixtemplates.templates.SpecialType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Custom postfix template for Ruby.
+ */
+@SuppressWarnings("WeakerAccess")
+public class CustomRubyStringPostfixTemplate extends SimpleStringBasedPostfixTemplate {
+
+	/** Contains predefined type-to-psiCondition mappings as well as cached mappings for individual types. */
+	private static final Map<String, Condition<PsiElement>> type2psiCondition = new HashMap<String, Condition<PsiElement>>() {{
+		put(SpecialType.ANY.name(), e -> true);
+	}};
+
+	public CustomRubyStringPostfixTemplate(String matchingClass, String conditionClass, String name, String example, String template, PostfixTemplateProvider provider, PsiElement psiElement) {
+		super(name, example, template, provider, psiElement, selectorAllExpressionsWithCurrentOffset(getCondition(matchingClass, conditionClass)));
+	}
+
+	@NotNull
+	public static Condition<PsiElement> getCondition(final @NotNull String matchingClass, final @Nullable String conditionClass) {
+		return type2psiCondition.get(matchingClass);
+	}
+}

--- a/src/de/endrullis/idea/postfixtemplates/languages/ruby/RubyAnnotator.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/ruby/RubyAnnotator.java
@@ -1,0 +1,36 @@
+package de.endrullis.idea.postfixtemplates.languages.ruby;
+
+import com.intellij.codeInsight.completion.CompletionParameters;
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import de.endrullis.idea.postfixtemplates.language.CptLangAnnotator;
+import de.endrullis.idea.postfixtemplates.templates.SpecialType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Code annotator for Ruby CPTs.
+ *
+ * @author YenTing Chen &lt;solofat@gmail.com&gt;
+ * @author Stefan Endrullis &lt;stefan@endrullis.de&gt;
+ */
+public class RubyAnnotator implements CptLangAnnotator {
+
+	private final Map<String, Boolean> className2exists = new HashMap<String, Boolean>() {{
+		put(SpecialType.ANY.name(), true);
+	}};
+
+	@Override
+	public boolean isMatchingType(@NotNull LeafPsiElement element, @NotNull String className) {
+		return className2exists.containsKey(className);
+	}
+
+	@Override
+	public void completeMatchingType(@NotNull CompletionParameters parameters, @NotNull CompletionResultSet resultSet) {
+		resultSet.addElement(LookupElementBuilder.create(SpecialType.ANY.name()));
+	}
+
+}

--- a/src/de/endrullis/idea/postfixtemplates/languages/ruby/RubyLang.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/ruby/RubyLang.java
@@ -1,0 +1,16 @@
+package de.endrullis.idea.postfixtemplates.languages.ruby;
+
+import de.endrullis.idea.postfixtemplates.language.CptLang;
+
+/**
+ * Language definition for Ruby.
+ *
+ * @author YenTing Chen &lt;solofat@gmail.com&gt;
+ */
+public class RubyLang extends CptLang {
+
+	public RubyLang() {
+		super("Ruby", RubyAnnotator.class);
+	}
+
+}

--- a/src/de/endrullis/idea/postfixtemplates/languages/ruby/RubyPostfixTemplateProvider.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/ruby/RubyPostfixTemplateProvider.java
@@ -1,0 +1,27 @@
+package de.endrullis.idea.postfixtemplates.languages.ruby;
+
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateProvider;
+import de.endrullis.idea.postfixtemplates.language.psi.CptMapping;
+import de.endrullis.idea.postfixtemplates.templates.CustomPostfixTemplateProvider;
+import org.jetbrains.annotations.NotNull;
+
+public class RubyPostfixTemplateProvider extends CustomPostfixTemplateProvider {
+
+	@NotNull
+	@Override
+	protected String getLanguage() {
+		return "ruby";
+	}
+
+	@Override
+	public String getPluginClassName() {
+		return "org.jetbrains.plugins.ruby.ruby.lang.psi.RubyExpressionCodeFragment";
+	}
+
+	@NotNull
+	@Override
+	protected CustomRubyStringPostfixTemplate createTemplate(CptMapping mapping, String matchingClass, String conditionClass, String templateName, String description, String template, PostfixTemplateProvider provider) {
+		return RubyStringPostfixTemplateCreator.createTemplate(mapping, matchingClass, conditionClass, templateName, description, template, provider);
+	}
+
+}

--- a/src/de/endrullis/idea/postfixtemplates/languages/ruby/RubyStringPostfixTemplateCreator.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/ruby/RubyStringPostfixTemplateCreator.java
@@ -1,0 +1,17 @@
+package de.endrullis.idea.postfixtemplates.languages.ruby;
+
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateProvider;
+import de.endrullis.idea.postfixtemplates.language.psi.CptMapping;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author YenTing Chen &lt;solofat@gmail.com&gt;
+ */
+class RubyStringPostfixTemplateCreator {
+
+	@NotNull
+	static CustomRubyStringPostfixTemplate createTemplate(CptMapping mapping, String matchingClass, String conditionClass, String templateName, String description, String template, PostfixTemplateProvider provider) {
+		return new CustomRubyStringPostfixTemplate(matchingClass, conditionClass, templateName, description, template, provider, mapping);
+	}
+
+}


### PR DESCRIPTION
This is to have the minimum support for Ruby, https://github.com/xylo/intellij-postfix-templates/issues/105.

I followed the [documentation](https://github.com/xylo/intellij-postfix-templates/wiki/Add-new-language-support) and changed a bit based on the implementations of Rust.

Here's the screen capture for the result.
![custom-postfix-template-ruby](https://user-images.githubusercontent.com/2877003/99027406-1d39e900-25a8-11eb-86e0-7173402c1360.gif)


References

* RubyMine introduced postfix completion since 2018.1 EAP, but the ability for developer to customize them has not yet been implemented. YouTrack ticket, [LINK](https://youtrack.jetbrains.com/issue/RUBY-22810).
* Declaration of Ruby plugin dependency [doc](https://jetbrains.org/intellij/sdk/docs/products/rubymine.html)