### PR TITLE
Add java junit5 templates

### DIFF
--- a/templates/java/yfr.junit5.postfixTemplates
+++ b/templates/java/yfr.junit5.postfixTemplates
@@ -1,0 +1,44 @@
+## Templates for JUnit 5 jupiter ##
+
+## Assert
+## skip assertLinesMatch, assertAll, assertTimesout, assertTimeoutPreemptively
+
+.fail : fail
+	java.lang.String [org.junit.jupiter.api.Assertions]            →  org.junit.jupiter.api.Assertions.fail($expr$)
+
+.assertTrue : assertTrue
+	java.lang.Boolean [org.junit.jupiter.api.Assertions]           →  org.junit.jupiter.api.Assertions.assertTrue($expr$)
+
+.assertFalse : assertFalse
+	java.lang.Boolean [org.junit.jupiter.api.Assertions]           →  org.junit.jupiter.api.Assertions.assertFalse($expr$)
+
+.assertNull : assertNull
+	ANY [org.junit.jupiter.api.Assertions]                         →  org.junit.jupiter.api.Assertions.assertNull($expr$)
+
+.assertNotNull : assertNotNull
+	ANY [org.junit.jupiter.api.Assertions]                         →  org.junit.jupiter.api.Assertions.assertNotNull($expr$)
+
+.assertSame : assertSame
+	ANY [org.junit.jupiter.api.Assertions]                         →  org.junit.jupiter.api.Assertions.assertSame($args$, $expr$)
+
+.assertNotSame : assertNotSame
+	ANY [org.junit.jupiter.api.Assertions]                         →  org.junit.jupiter.api.Assertions.assertNotSame($args$, $expr$)
+
+.assertEquals : assertEquals
+	ANY [org.junit.jupiter.api.Assertions]                         →  org.junit.jupiter.api.Assertions.assertEquals($args$, $expr$)
+
+.assertNotEquals : assertNotEquals
+	ANY [org.junit.jupiter.api.Assertions]                         →  org.junit.jupiter.api.Assertions.assertNotEquals($args$, $expr$)
+
+.assertThrows : assertThrows
+	ANY [org.junit.jupiter.api.Assertions]                         →  org.junit.jupiter.api.Assertions.assertThrows($expr$, $args$)
+
+.assertDoesNotThrow : assertDoesNotThrow
+	ANY [org.junit.jupiter.api.Assertions]                         →  org.junit.jupiter.api.Assertions.assertDoesNotThrow($expr$, $args$)
+
+.assertArrayEquals : assertEquals
+	ARRAY [org.junit.jupiter.api.Assertions]                       →  org.junit.jupiter.api.Assertions.assertArrayEquals($args$, $expr$)
+
+.assertIterableEquals : assertIterableEquals
+	java.lang.Iterable [org.junit.jupiter.api.Assertions]          →  org.junit.jupiter.api.Assertions.assertIterableEquals($args$, $expr$)
+

--- a/templates/webTemplateFiles.yaml
+++ b/templates/webTemplateFiles.yaml
@@ -283,3 +283,10 @@
   email: yfr.huang@hotmail.com
   website: https://github.com/xylo/intellij-postfix-templates/wiki/Kotlin-web-templates:-yfr.mockito
   description: Provides templates for Mockito
+- lang: java
+  id: yfr.junit5
+  url: https://raw.githubusercontent.com/xylo/intellij-postfix-templates/master/templates/java/yfr.junit5.postfixTemplates
+  author: Jian-Min-Huang
+  email: yfr.huang@hotmail.com
+  website: https://github.com/xylo/intellij-postfix-templates/wiki/Java-web-templates:-yfr.junit5
+  description: Provides templates for JUnit 5


### PR DESCRIPTION
* add yfr.junit5 postfixTemplates for supporting Java Junit5
* update webTemplateFiles.yaml

@xylo can id be duplicated ? because id: yfr.junit5 already used in kotlin web template