### PR TITLE
add Swift untyped postfix support

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -575,6 +575,8 @@
 		                                              implementationClass="de.endrullis.idea.postfixtemplates.languages.javascript.JavaScriptPostfixTemplateProvider"/>
 		<codeInsight.template.postfixTemplateProvider language="SQL"
 		                                              implementationClass="de.endrullis.idea.postfixtemplates.languages.sql.SqlPostfixTemplateProvider"/>
+		<codeInsight.template.postfixTemplateProvider language="Swift"
+													  implementationClass="de.endrullis.idea.postfixtemplates.languages.swift.SwiftPostfixTemplateProvider"/>
 		<!--
 		<codeInsight.template.postfixTemplateProvider language="C#"
 		                                              implementationClass="de.endrullis.idea.postfixtemplates.languages.csharp.CsharpPostfixTemplateProvider"/>

--- a/resources/postfixTemplates/CustomSwiftStringPostfixTemplate/after.java.template
+++ b/resources/postfixTemplates/CustomSwiftStringPostfixTemplate/after.java.template
@@ -1,0 +1,2 @@
+// this is a custom template defined by the user
+// see "Custom Postfix Templates" for template definition

--- a/resources/postfixTemplates/CustomSwiftStringPostfixTemplate/before.java.template
+++ b/resources/postfixTemplates/CustomSwiftStringPostfixTemplate/before.java.template
@@ -1,0 +1,2 @@
+// this is a custom template defined by the user
+// see "Custom Postfix Templates" for template definition

--- a/resources/postfixTemplates/CustomSwiftStringPostfixTemplate/description.html
+++ b/resources/postfixTemplates/CustomSwiftStringPostfixTemplate/description.html
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2000-2017 JetBrains s.r.o.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<html>
+<body>
+
+Custom postfix template.
+</body>
+</html>

--- a/src/de/endrullis/idea/postfixtemplates/languages/swift/CustomSwiftStringPostfixTemplate.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/swift/CustomSwiftStringPostfixTemplate.java
@@ -1,0 +1,23 @@
+package de.endrullis.idea.postfixtemplates.languages.swift;
+
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateProvider;
+import com.intellij.lang.javascript.psi.JSExpressionStatement;
+import com.intellij.lang.javascript.template.postfix.JSPostfixTemplateUtils;
+import com.intellij.psi.PsiElement;
+import de.endrullis.idea.postfixtemplates.templates.SimpleStringBasedPostfixTemplate;
+/*  */
+/**
+ * Custom postfix template for Swift.
+ */
+@SuppressWarnings("WeakerAccess")
+public class CustomSwiftStringPostfixTemplate extends SimpleStringBasedPostfixTemplate {
+
+	public CustomSwiftStringPostfixTemplate(String clazz, String name, String example, String template, PostfixTemplateProvider provider, PsiElement psiElement) {
+		super(name, example, template, provider, psiElement, JSPostfixTemplateUtils.selectorTopmost());
+	}
+
+	protected PsiElement getElementToRemove(PsiElement expr) {
+   return expr.getParent() instanceof JSExpressionStatement ? expr : super.getElementToRemove(expr);
+ }
+
+}

--- a/src/de/endrullis/idea/postfixtemplates/languages/swift/SwiftAnnotator.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/swift/SwiftAnnotator.java
@@ -1,0 +1,35 @@
+package de.endrullis.idea.postfixtemplates.languages.swift;
+
+import com.intellij.codeInsight.completion.CompletionParameters;
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import de.endrullis.idea.postfixtemplates.language.CptLangAnnotator;
+import de.endrullis.idea.postfixtemplates.templates.SpecialType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Code annotator for Swift CPTs.
+ *
+ * @author Stefan Endrullis &lt;stefan@endrullis.de&gt;
+ */
+public class SwiftAnnotator implements CptLangAnnotator {
+
+	private final Map<String, Boolean> className2exists = new HashMap<>() {{
+		put(SpecialType.ANY.name(), true);
+	}};
+
+	@Override
+	public boolean isMatchingType(@NotNull LeafPsiElement element, @NotNull String className) {
+		return className2exists.containsKey(className);
+	}
+
+	@Override
+	public void completeMatchingType(@NotNull CompletionParameters parameters, @NotNull CompletionResultSet resultSet) {
+		resultSet.addElement(LookupElementBuilder.create(SpecialType.ANY.name()));
+	}
+
+}

--- a/src/de/endrullis/idea/postfixtemplates/languages/swift/SwiftLang.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/swift/SwiftLang.java
@@ -1,0 +1,16 @@
+package de.endrullis.idea.postfixtemplates.languages.swift;
+
+import de.endrullis.idea.postfixtemplates.language.CptLang;
+
+/**
+ * Language definition for Java.
+ *
+ * @author Stefan Endrullis &lt;stefan@endrullis.de&gt;
+ */
+public class SwiftLang extends CptLang {
+
+	public SwiftLang() {
+		super("Swift", SwiftAnnotator.class);
+	}
+
+}

--- a/src/de/endrullis/idea/postfixtemplates/languages/swift/SwiftPostfixTemplateProvider.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/swift/SwiftPostfixTemplateProvider.java
@@ -1,0 +1,27 @@
+package de.endrullis.idea.postfixtemplates.languages.swift;
+
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateProvider;
+import de.endrullis.idea.postfixtemplates.language.psi.CptMapping;
+import de.endrullis.idea.postfixtemplates.templates.CustomPostfixTemplateProvider;
+import org.jetbrains.annotations.NotNull;
+
+public class SwiftPostfixTemplateProvider extends CustomPostfixTemplateProvider {
+
+	@NotNull
+	@Override
+	protected String getLanguage() {
+		return "swift";
+	}
+
+	@Override
+	public String getPluginClassName() {
+		return "com.intellij.lang.swift.template.postfix.JSPostfixTemplateUtils";
+	}
+
+	@NotNull
+	@Override
+	protected CustomSwiftStringPostfixTemplate createTemplate(CptMapping mapping, String matchingClass, String conditionClass, String templateName, String description, String template, PostfixTemplateProvider provider) {
+		return new CustomSwiftStringPostfixTemplate(matchingClass, templateName, description, template, provider, mapping);
+	}
+
+}

--- a/src/de/endrullis/idea/postfixtemplates/languages/swift/SwiftPostfixTemplatesUtils.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/swift/SwiftPostfixTemplatesUtils.java
@@ -1,0 +1,32 @@
+package de.endrullis.idea.postfixtemplates.languages.swift;
+
+import com.intellij.codeInsight.completion.CompletionParameters;
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.lang.javascript.index.JavaScriptIndex;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Utilities for PHP postfix templates.
+ *
+ * @author Stefan Endrullis &lt;stefan@endrullis.de&gt;
+ */
+class SwiftPostfixTemplatesUtils {
+
+	/*
+	static boolean isInstanceOf(@NotNull JavaScriptTypeHelper subType, @NotNull PhpType superType, PsiElement psiElement) {
+		JavaScriptTypeHelper.getInstance().getTypeForIndexing(psiElement);
+
+		return superType.isConvertibleFrom(subType, PhpIndex.getInstance(psiElement.getProject()));
+	}
+	*/
+
+	static boolean isProjectClass(@NotNull String conditionClass, PsiElement e) {
+		return JavaScriptIndex.getInstance(e.getProject()).getClassByName(conditionClass, true) != null;
+	}
+
+	static void addCompletions(CompletionParameters parameters, CompletionResultSet resultSet) {
+		// TODO
+	}
+
+}


### PR DESCRIPTION
I tried my best to support Swift. For me, I only have AppCode for developing Swift. Can someone help me check if PR satisfies the `the file type detection works.` in https://github.com/xylo/intellij-postfix-templates/wiki/Add-new-language-support.

I am quite new to intellij, if I learn it right, AppCode was just a different tool, but the plugin platform is the same across those IDEs. 