### PR TITLE
MAP and STRUCT to the matching types for the Go language

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ The options for *MATCHING_TYPE* may differ from programming language to programm
   * `ERROR` - any error expression
   * `COMPLEX` - ???
   * `NIL` - any expression of type Nil
+  * `MAP` - any MAP expression
+  * `STRUCT` - any struct point  expression
 * In **Groovy** the *MATCHING_TYPE* can be either a Java/Groovy class name or one of the following special types:
   * `ANY` - any expression
   * `ARRAY` - any Java array

--- a/resources/META-INF/withJavaModule.xml
+++ b/resources/META-INF/withJavaModule.xml
@@ -1,6 +1,8 @@
 <idea-plugin>
 	<extensions defaultExtensionNs="com.intellij">
 		<liveTemplateMacro implementation="de.endrullis.idea.postfixtemplates.templates.macro.SuggestShortVariableNameMacro"/>
+		<liveTemplateMacro implementation="de.endrullis.idea.postfixtemplates.templates.macro.GoArrayElementTypeNameMacro"/>
+		<liveTemplateMacro implementation="de.endrullis.idea.postfixtemplates.templates.macro.GoMapKeyTypeNameMacro"/>
 
 		<codeInsight.template.postfixTemplateProvider language="JAVA"
 		                                              implementationClass="de.endrullis.idea.postfixtemplates.languages.java.JavaPostfixTemplateProvider"/>

--- a/resources/META-INF/withJavaModule.xml
+++ b/resources/META-INF/withJavaModule.xml
@@ -3,6 +3,7 @@
 		<liveTemplateMacro implementation="de.endrullis.idea.postfixtemplates.templates.macro.SuggestShortVariableNameMacro"/>
 		<liveTemplateMacro implementation="de.endrullis.idea.postfixtemplates.templates.macro.GoArrayElementTypeNameMacro"/>
 		<liveTemplateMacro implementation="de.endrullis.idea.postfixtemplates.templates.macro.GoMapKeyTypeNameMacro"/>
+		<liveTemplateMacro implementation="de.endrullis.idea.postfixtemplates.templates.macro.GoMapValueTypeNameMacro"/>
 
 		<codeInsight.template.postfixTemplateProvider language="JAVA"
 		                                              implementationClass="de.endrullis.idea.postfixtemplates.languages.java.JavaPostfixTemplateProvider"/>

--- a/src/de/endrullis/idea/postfixtemplates/languages/go/CustomGoStringPostfixTemplate.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/go/CustomGoStringPostfixTemplate.java
@@ -43,6 +43,9 @@ public class CustomGoStringPostfixTemplate extends SimpleStringBasedPostfixTempl
 		put(GoSpecialType.COMPLEX.name(), IS_COMPLEX);
 		put(GoSpecialType.NIL.name(), IS_NIL);
 		put(GoSpecialType.STRING.name(), IS_STRING);
+		put(GoSpecialType.STRUCT.name(), IS_STRUCT);
+		put(GoSpecialType.MAP.name(), IS_MAP);
+
 	}};
 
 	public static @NotNull List<PsiElement> collectExpressions(final PsiFile file,

--- a/src/de/endrullis/idea/postfixtemplates/languages/go/GoSpecialType.java
+++ b/src/de/endrullis/idea/postfixtemplates/languages/go/GoSpecialType.java
@@ -8,6 +8,6 @@ package de.endrullis.idea.postfixtemplates.languages.go;
  */
 public enum GoSpecialType {
 
-	ANY, BOOLEAN, STRING, INT, INT64, UINT, FLOAT, FLOAT32, FLOAT64, BYTESLICE, ERROR, COMPLEX, ARRAY, NIL
+	ANY, BOOLEAN, STRING, INT, INT64, UINT, FLOAT, FLOAT32, FLOAT64, BYTESLICE, ERROR, COMPLEX, ARRAY, NIL , MAP, STRUCT
 
 }

--- a/src/de/endrullis/idea/postfixtemplates/templates/macro/GoArrayElementTypeNameMacro.java
+++ b/src/de/endrullis/idea/postfixtemplates/templates/macro/GoArrayElementTypeNameMacro.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2000-2009 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.endrullis.idea.postfixtemplates.templates.macro;
+
+import com.goide.psi.GoConstDefinition;
+import com.goide.psi.GoType;
+import com.goide.psi.GoTypeOwner;
+import com.goide.psi.impl.GoPsiImplUtil;
+import com.goide.psi.impl.GoTypeUtil;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.template.*;
+import com.intellij.codeInsight.template.macro.MacroUtil;
+import com.intellij.psi.*;
+import de.endrullis.idea.postfixtemplates.utils.GoTypeElementUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class GoArrayElementTypeNameMacro extends Macro {
+
+    public static final String NAME = "goArrayElementTypeName";
+    public static final String PRESENT_TABLE_NAME = GoTypeElementUtils.getPresentableName(NAME);
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getPresentableName() {
+        return PRESENT_TABLE_NAME;
+    }
+
+    @Override
+    @NotNull
+    public String getDefaultValue() {
+        return "any";
+    }
+
+    @Override
+    public Result calculateResult(@NotNull Expression @NotNull [] params, ExpressionContext context) {
+        String typeName = GoTypeElementUtils.findElementGenericName(params, context, element -> {
+            String name = "";
+            if (element instanceof GoTypeOwner) {
+
+                ResolveState resolveState = !(element instanceof GoConstDefinition) && context != null ?
+                        GoPsiImplUtil.createContextOnElement(element.getContext()) : null;
+
+                GoType type = ((GoTypeOwner) element).getGoType(resolveState);
+                if (type == null) {
+                    return name;
+                }
+                return GoTypeElementUtils.nullObjectToDefault(GoTypeUtil.getArrayOrSliceElementType(type), "", GoType::getText);
+            }
+            return name;
+        });
+
+        return new TextResult(typeName);
+    }
+
+
+    @Nullable
+    @Override
+    public Result calculateQuickResult(@NotNull Expression @NotNull [] params, ExpressionContext context) {
+        return calculateResult(params, context);
+    }
+
+    @Override
+    public LookupElement[] calculateLookupItems(@NotNull Expression @NotNull [] params, final ExpressionContext context) {
+        PsiFile file = PsiDocumentManager.getInstance(context.getProject()).getPsiFile(context.getEditor().getDocument());
+        PsiElement e = file.findElementAt(context.getStartOffset());
+        PsiVariable[] vars = MacroUtil.getVariablesVisibleAt(e, "");
+        LookupElement[] items = new LookupElement[0];
+        return items;
+    }
+
+
+    @Override
+    public boolean isAcceptableInContext(TemplateContextType context) {
+        return context instanceof JavaCodeContextType;
+    }
+
+}

--- a/src/de/endrullis/idea/postfixtemplates/templates/macro/GoMapKeyTypeNameMacro.java
+++ b/src/de/endrullis/idea/postfixtemplates/templates/macro/GoMapKeyTypeNameMacro.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2009 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.endrullis.idea.postfixtemplates.templates.macro;
+
+import com.goide.psi.GoMapType;
+import com.intellij.codeInsight.template.*;
+import com.intellij.psi.PsiElement;
+import de.endrullis.idea.postfixtemplates.utils.GoTypeElementUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class GoMapKeyTypeNameMacro extends Macro {
+
+    public static final String NAME = "goMapKeyType";
+    public static final String PRESENT_TABLE_NAME = GoTypeElementUtils.getPresentableName(NAME);
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getPresentableName() {
+        return PRESENT_TABLE_NAME;
+    }
+
+    @Override
+    @NotNull
+    public String getDefaultValue() {
+        return "any";
+    }
+
+    @Override
+    public Result calculateResult(@NotNull Expression @NotNull [] params, ExpressionContext context) {
+
+        String typeName = GoTypeElementUtils.findElementGenericName(params, context, element -> {
+            if (element instanceof GoMapType) {
+                return GoTypeElementUtils.nullObjectToDefault(((GoMapType) element).getKeyType(), "", PsiElement::getText);
+            }
+
+            return "";
+        });
+        return new TextResult(typeName);
+    }
+
+
+    @Nullable
+    @Override
+    public Result calculateQuickResult(@NotNull Expression @NotNull [] params, ExpressionContext context) {
+        return calculateResult(params, context);
+    }
+
+    @Override
+    public boolean isAcceptableInContext(TemplateContextType context) {
+        return context instanceof JavaCodeContextType;
+    }
+
+}

--- a/src/de/endrullis/idea/postfixtemplates/templates/macro/GoMapValueTypeNameMacro.java
+++ b/src/de/endrullis/idea/postfixtemplates/templates/macro/GoMapValueTypeNameMacro.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2000-2009 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.endrullis.idea.postfixtemplates.templates.macro;
+
+import com.goide.psi.GoMapType;
+import com.intellij.codeInsight.template.*;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.ArrayUtil;
+import de.endrullis.idea.postfixtemplates.utils.GoTypeElementUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class GoMapValueTypeNameMacro extends Macro {
+
+    public static final String NAME = "goMapValueType";
+    public static final String PRESENT_TABLE_NAME = GoTypeElementUtils.getPresentableName(NAME);
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getPresentableName() {
+        return PRESENT_TABLE_NAME;
+    }
+
+    @Override
+    @NotNull
+    public String getDefaultValue() {
+        return "any";
+    }
+
+    @Override
+    public Result calculateResult(@NotNull Expression @NotNull [] params, ExpressionContext context) {
+        String typeName = GoTypeElementUtils.findElementGenericName(params, context, element -> {
+            if (element instanceof GoMapType) {
+                return GoTypeElementUtils.nullObjectToDefault(((GoMapType) element).getValueType(), "", PsiElement::getText);
+            }
+
+            return "";
+        });
+        return new TextResult(typeName);
+    }
+
+
+    @Nullable
+    @Override
+    public Result calculateQuickResult(@NotNull Expression @NotNull [] params, ExpressionContext context) {
+        return calculateResult(params, context);
+    }
+
+    @Override
+    public boolean isAcceptableInContext(TemplateContextType context) {
+        return context instanceof JavaCodeContextType;
+    }
+
+}

--- a/src/de/endrullis/idea/postfixtemplates/utils/GoTypeElementUtils.java
+++ b/src/de/endrullis/idea/postfixtemplates/utils/GoTypeElementUtils.java
@@ -1,0 +1,56 @@
+package de.endrullis.idea.postfixtemplates.utils;
+
+import com.intellij.codeInsight.template.Expression;
+import com.intellij.codeInsight.template.ExpressionContext;
+import com.intellij.codeInsight.template.Result;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.ArrayUtil;
+import com.intellij.util.Function;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/**
+ * @author yarkizhang
+ * @date 2024/8/12
+ */
+public class GoTypeElementUtils {
+
+    public static String getPresentableName(@NotNull String name) {
+        return name+"()";
+    }
+
+    public static String findElementGenericName(@NotNull Expression @NotNull [] params, ExpressionContext context, Function<PsiElement, String> f) {
+        if (params.length == 0) {
+            return "";
+        }
+
+        Expression param = ArrayUtil.getFirstElement(params);
+        Result paramResult = param != null ? param.calculateResult(context) : null;
+        String paramText = paramResult != null ? paramResult.toString() : null;
+        PsiElement element = context.getPsiElementAtStartOffset();
+
+        PsiElement[] psiElements = PsiTreeUtil.collectElements(element.getContext(),
+                psiElement -> psiElement.getText().equals(paramText));
+
+        if (psiElements.length > 0) {
+            element = psiElements[0];
+            if (element instanceof LeafPsiElement) {
+                element = element.getParent();
+            }
+            return f.apply(element);
+        }
+        return "";
+
+    }
+
+    public static <T, V> V nullObjectToDefault(T t, V v, Function<T, V> f) {
+        if (Objects.isNull(t)) {
+            return v;
+        }
+        return f.apply(t);
+    }
+
+}


### PR DESCRIPTION
1. Add MAP and STRUCT to the matching types for the Go language.
2. Add a method to get the element type in arrays and slices: goArrayElementTypeName.
3. Add a method to get the key type in maps: goMapKeyType.
4. Add a method to get the value type in maps: goMapValueType.