### PR TITLE
Fix plugin error warnings in the latest version of IntelliJ IDEA

### DIFF
--- a/src/de/endrullis/idea/postfixtemplates/language/CptCodeStyleSettingsProvider.java
+++ b/src/de/endrullis/idea/postfixtemplates/language/CptCodeStyleSettingsProvider.java
@@ -32,4 +32,9 @@ public class CptCodeStyleSettingsProvider extends CodeStyleSettingsProvider {
 		};
 	}
 
+	@Nullable
+	@Override
+	public com.intellij.lang.Language getLanguage() {
+		return CptLanguage.INSTANCE;
+	}
 }

--- a/src/de/endrullis/idea/postfixtemplates/settings/WebTemplateFileLoader.java
+++ b/src/de/endrullis/idea/postfixtemplates/settings/WebTemplateFileLoader.java
@@ -1,7 +1,6 @@
 package de.endrullis.idea.postfixtemplates.settings;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,7 +13,7 @@ import java.io.IOException;
 public class WebTemplateFileLoader {
 
 	public static WebTemplateFile[] load(File file) throws IOException {
-		ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+		YAMLMapper mapper = new YAMLMapper();
 		return mapper.readValue(file, WebTemplateFile[].class);
 	}
 


### PR DESCRIPTION
1. Replace `ObjectMapper` with `YAMLMapper` for YAML parsing. 
2. Add language support in `CptCodeStyleSettingsProvider`.